### PR TITLE
Add fn strip-margin

### DIFF
--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -473,6 +473,15 @@
   (-> (slurp-resource path)
       edn/read-string))
 
+(defn strip-margin
+  ([string]
+   (strip-margin string "\\|"))
+  ([string delimiter] (->> string
+                           s/split-lines
+                           (map s/triml)
+                           (map #(.replaceFirst % delimiter ""))
+                           (s/join "\n"))))
+
 ;; threads
 
 (defn show-threads


### PR DESCRIPTION
Similar to [`String.stripMargin`](https://www.scala-lang.org/api/current/scala/collection/StringOps.html#stripMargin:String) extension method in Scala; e.g.:
```clojure
(require '[yang.lang :as yl])
=> nil

(println
  (yl/strip-margin "|<?xml version='1.0' encoding='utf-8'?>
                    |<people>
                    |  <person>
                    |    <name>Joe Smith</name>
                    |  </person>
                    |</people>"))
<?xml version='1.0' encoding='utf-8'?>
<people>
  <person>
    <name>Joe Smith</name>
  </person>
</people>
=> nil
```

Signed-off-by: Daniel Miladinov <daniel.miladinov@gmail.com>