### PR TITLE
additional util to convert Seq->Hash-map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ tree:
 
 repl:
 	clojure -A:dev -A:repl
+
+test-it:
+	clojure -X:test

--- a/deps.edn
+++ b/deps.edn
@@ -1,21 +1,26 @@
 {:paths ["src" "classes"]
  :deps {}
- :aliases {:dev {:extra-deps {metosin/jsonista {:mvn/version "0.3.4"}}}
-           :repl {;; :extra-paths ["test" "test/resources"]
-                  :extra-deps {nrepl/nrepl {:mvn/version "0.7.0"}
-                               cider/cider-nrepl {:mvn/version "0.22.4"}
-                               org.clojure/tools.logging {:mvn/version "1.2.4"}
-                               com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
-                  :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"
-                              "-i" "-f" "rebel-readline.main/-main"]}
-           :outdated {:extra-deps {olical/depot {:mvn/version "2.0.1"}}
-                      :main-opts  ["-m" "depot.outdated.main" "-a" "outdated"]}
-           :tag {:extra-deps {tolitius/tag {:mvn/version "0.1.7"}}
-                 :main-opts ["-m" "tag.core" "tolitius/yang" "the yang of Clojure's ying"]}
-           :jar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.128"}}
-                 :extra-paths ["target/about"]
-                 :main-opts ["-m" "hf.depstar.jar" "target/yang.jar" "--exclude" "clojure/core/specs/alpha.*"]}
-           :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
-                    :main-opts ["-m" "deps-deploy.deps-deploy" "deploy" "target/yang.jar"]}
-           :install {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
-                     :main-opts ["-m" "deps-deploy.deps-deploy" "install" "target/yang.jar"]}}}
+ :aliases {:dev       {:extra-deps {metosin/jsonista {:mvn/version "0.3.4"}}}
+           :repl      {;; :extra-paths ["test" "test/resources"]
+                       :extra-deps {nrepl/nrepl {:mvn/version "0.7.0"}
+                                    cider/cider-nrepl {:mvn/version "0.22.4"}
+                                    org.clojure/tools.logging {:mvn/version "1.2.4"}
+                                    com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+                       :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"
+                                  "-i" "-f" "rebel-readline.main/-main"]}
+            :outdated {:extra-deps {olical/depot {:mvn/version "2.0.1"}}
+                       :main-opts  ["-m" "depot.outdated.main" "-a" "outdated"]}
+           :tag       {:extra-deps {tolitius/tag {:mvn/version "0.1.7"}}
+                       :main-opts ["-m" "tag.core" "tolitius/yang" "the yang of Clojure's ying"]}
+           :jar       {:extra-deps {seancorfield/depstar {:mvn/version "1.1.128"}}
+                       :extra-paths ["target/about"]
+                       :main-opts ["-m" "hf.depstar.jar" "target/yang.jar" "--exclude" "clojure/core/specs/alpha.*"]}
+           :deploy    {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
+                       :main-opts ["-m" "deps-deploy.deps-deploy" "deploy" "target/yang.jar"]}
+           :install   {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
+                       :main-opts ["-m" "deps-deploy.deps-deploy" "install" "target/yang.jar"]}
+           :test {:extra-paths ["test"]
+                  :exec-fn     cognitect.test-runner.api/test
+                  :main-opts   ["-m" "cognitect.test-runner"] 
+                  :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                                org.clojure/test.check               {:mvn/version "RELEASE"}}}}}

--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -554,3 +554,12 @@
   (let [f (.. obj getClass (getDeclaredField field))]
     (. f (setAccessible true))
     (. f (get obj))))
+
+(defn seq->hash-map
+  "Convert Sequential type to PersistentHashMap"
+  [{:keys [key-fn val-fn]
+    :or {key-fn hash
+         val-fn identity}} list-of-vals]
+  (->> (for [item list-of-vals]
+         [(key-fn item) (val-fn item)])
+       (into {})))

--- a/test/yang/lang_test.clj
+++ b/test/yang/lang_test.clj
@@ -1,0 +1,28 @@
+(ns yang.lang-test
+  (:require [yang.lang :as yl]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest ^:support-converting-seq-of-values-into-hashmap
+  validate-seq->hash-map
+  (let [case1 "convert list of values into hash-map"]
+    (println case1)
+    (testing case1
+      (let [input  [1 2 3 4]
+            output (yl/seq->hash-map {:key-fn dec} input)]
+        (is (= 1 (get output 0))
+        (is (= 2 (get output 1))
+        (is (= {0 1
+                1 2
+                2 3
+                3 4}
+               output)))))))
+  (let [case2 "convert list of map into hash-map"]
+    (println case2)
+    (testing case2
+      (let [input  [{:name "VickySuraj" :id "vicky-suraj"}
+                    {:name "Anatoly"    :id "tolitius"}]
+            output (yl/seq->hash-map {:key-fn (comp keyword :id)
+                                      :val-fn (comp (partial str "Hi I am ") :name)}
+                                     input)]
+        (is (= "Hi I am VickySuraj" (:vicky-suraj output))
+        (is (= "Hi I am Anatoly" (:tolitius output))))))))


### PR DESCRIPTION
 ## Fixes done
* Added a new _util fn_ **seq->hash-map** which will convert _sequential/iterable_ datatype into `hash-map`

 ## Changelog
* Added **yang.lang/seq->hash-map**
* Modified **deps.edn** to support `test` aliases
* Modified **Makefile** added `test-it` function to execute the test-cases

 ## Unit testing
* Added `test` folder
<img width="1531" alt="Screenshot 2023-05-31 at 7 38 29 PM" src="https://github.com/tolitius/yang/assets/42887658/5af73094-7011-4cc9-bc47-491b50d2d8b2">
