### PR TITLE
Rewrite rfmk/rfmv: fix semantics, improve performance, deprecate fmk/fmv

### DIFF
--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -39,42 +39,46 @@
     (UUID/fromString s)))
 
 (defn fmv
-  "apply f to each value v of map m"
+  "DEPRECATED: Use clojure.core/update-vals instead.
+   apply f to each value v of map m"
+  {:added      "0.1.0"
+   :deprecated "0.1.51"}
   [m f]
-  (into {}
-        (for [[k v] m]
-          [k (f v)])))
+  (update-vals m f))
 
 (defn fmk
-  "apply f to each key k of map m"
+  "DEPRECATED: Use clojure.core/update-keys instead.
+   apply f to each key k of map m"
+  {:added      "0.1.0"
+   :deprecated "0.1.51"}
   [m f]
-  (into {}
-        (for [[k v] m]
-          [(f k) v])))
+  (update-keys m f))
 
 (defn rfmk
   "recursively apply f to each key k of map m"
+  {:added "0.1.26"}
   [m f]
-  (let [fun (fn [[k v]]
-              (if (or (string? k)
-                      (simple-keyword? k))
-                [(f k) v]
-                [k v]))]
-    (walk/postwalk (fn [x]
-                     (if (map? x)
-                       (into {}
-                             (map fun x)) x))
-                   m)))
+  (letfn [(walk [x]
+            (cond
+              (map? x)        (update-keys (update-vals x walk) f)
+              (vector? x)     (mapv walk x)
+              (set? x)        (into #{} (map walk) x)
+              (sequential? x) (map walk x)
+              :else           x))]
+    (update-keys (update-vals m walk) f)))
 
 (defn rfmv
   "recursively apply f to each value v of map m"
+  {:added "0.1.45"}
   [m f]
-  (into {}
-        (map (fn [[k v]]
-               [k (if (map? v)
-                    (rfmv v f)
-                    (f v))]))
-        m))
+  (letfn [(walk [x]
+            (cond
+              (map? x)        (update-vals x walk)
+              (vector? x)     (mapv walk x)
+              (set? x)        (into #{} (map walk) x)
+              (sequential? x) (map walk x)
+              :else           (f x)))]
+    (update-vals m walk)))
 
 (defn assoc-if
     "associates key/value pairs into the map `m` if the values are not nil


### PR DESCRIPTION
Rewrite `rfmk` and `rfmv` to use explicit recursion with Clojure 1.11's `update-keys`/`update-vals`, replacing the previous `postwalk` + `into {}`
+ `map` + destructuring approach. Deprecate `fmk` and `fmv` in favor of their `clojure.core` equivalents (`update-keys`, `update-vals`).

Semantic fixes
--------------

**rfmk**: The original implementation used a `(string? k)` / `(simple-keyword? k)` type guard that silently skipped qualified keywords and non-keyword/non-string keys. This was confirmed by the original author to be incidental, not intentional. The new implementation applies `f` to every key unconditionally.

**rfmv**: The original implementation (commit 0ac4647) used `postwalk` but had a bug -- it applied `f` to sub-maps themselves, not just leaf values. The fix (commit 0341fda, message "fix rmfv") replaced `postwalk` with explicit recursion but silently changed traversal semantics: it could no longer reach maps nested inside vectors, sets, or lists. The new implementation walks into all collection types (vectors, sets, sequences) to find and transform maps at any depth.

Both functions now use a symmetric `letfn` + `cond` dispatch pattern that explicitly handles maps, vectors, sets, and sequences.

Benchmark Script Code
------------------------
```clojure
(ns improving-performance-of-rfmk-and-rfmv
  "Benchmark comparing the original yang.lang/{rfmk,rfmv} implementations
   against the optimized explicit-recursion + update-keys/update-vals versions
   now live in yang.lang.

   The old implementations are inlined below for A/B comparison.
   The new implementations are used directly from yang.lang.

   Run each form in a REPL (Cursive: Ctrl+Shift+P / Cmd+Shift+P)."
  (:require [clojure.walk :as walk]
            [yang.lang :as lang]))

;; ---------------------------------------------------------------------------
;; 1. The old yang.lang implementations (pre-optimization, inlined)
;; ---------------------------------------------------------------------------

(defn rfmk-old
  "original yang.lang/rfmk -- postwalk + into {} + map + destructuring"
  [m f]
  (let [fun (fn [[k v]]
              (if (or (string? k)
                      (simple-keyword? k))
                [(f k) v]
                [k v]))]
    (walk/postwalk (fn [x]
                     (if (map? x)
                       (into {}
                             (map fun x)) x))
                   m)))

(defn rfmv-old
  "original yang.lang/rfmv -- into {} + map transducer + destructuring"
  [m f]
  (into {}
        (map (fn [[k v]]
               [k (if (map? v)
                    (rfmv-old v f)
                    (f v))]))
        m))

;; ---------------------------------------------------------------------------
;; 2. Test data generators
;; ---------------------------------------------------------------------------

(defn gen-flat-map
  "Generate a flat map of `n` entries {:k0 0, :k1 1, ...}."
  [n]
  (zipmap (map #(keyword (str "k" %)) (range n))
          (range n)))

(defn gen-nested-map
  "Generate a nested map with `breadth` keys at each level and `depth` levels.
   Leaf values are integers. Total entries = breadth^depth (approx)."
  [breadth depth]
  (if (<= depth 1)
    (gen-flat-map breadth)
    (zipmap (map #(keyword (str "k" %)) (range breadth))
            (repeat breadth (gen-nested-map breadth (dec depth))))))

(defn count-entries
  "Count total key-value pairs across all levels of a nested map."
  [m]
  (reduce-kv (fn [acc _k v]
               (+ acc 1 (if (map? v) (count-entries v) 0)))
             0
             m))

(def flat-sizes
  "Flat map sizes to benchmark."
  [10 100 1000 10000])

(def nested-configs
  "Nested map configs: [breadth depth description]."
  [[5 3 "5^3 = 125 leaves"]
   [10 3 "10^3 = 1,000 leaves"]
   [5 4 "5^4 = 625 leaves"]
   [10 2 "10^2 = 100 leaves"]
   [20 2 "20^2 = 400 leaves"]
   [3 5 "3^5 = 243 leaves"]])

;; ---------------------------------------------------------------------------
;; 3. Timing helpers (same as superseding-fmk-and-fmv.clj)
;; ---------------------------------------------------------------------------

(defn warm-up!
  "JIT warm-up: run f 5000 times, discard results."
  [f]
  (dotimes [_ 5000] (f))
  :warmed)

(defn bench
  "Time `f` (a thunk) over `iterations` runs.
   Returns {:mean-ns :min-ns :max-ns :median-ns :total-ms :iterations}."
  ([f] (bench f 1000))
  ([f iterations]
   (warm-up! f)
   (let [times (long-array iterations)]
     (dotimes [i iterations]
       (let [start (System/nanoTime)
             _     (f)
             end   (System/nanoTime)]
         (aset times i (- end start))))
     (let [sorted (sort (seq times))
           total  (reduce + sorted)]
       {:mean-ns    (long (/ total iterations))
        :min-ns     (first sorted)
        :max-ns     (last sorted)
        :median-ns  (nth sorted (/ iterations 2))
        :total-ms   (/ total 1e6)
        :iterations iterations}))))

;; ---------------------------------------------------------------------------
;; 4. Load profiling dependencies
;; ---------------------------------------------------------------------------
;; clj-memory-meter 0.4.0 and clj-async-profiler 1.7.0 are provided by the
;; :profiling alias in yang's deps.edn.
;;
;; Profiling alias as follows:
;;   :profiling {:extra-deps {com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.4.0"}
;;                            com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.7.0"}}
;;               :jvm-opts ["-Djdk.attach.allowAttachSelf"
;;                          "--add-opens" "java.base/java.util=ALL-UNNAMED"
;;                          "--add-opens" "java.base/java.lang=ALL-UNNAMED"]}
;;
;; Start your Cursive REPL with:
;;
;;   Deps option:  -A:dev:profiling
;;
;; PREREQUISITES (JVM flags -- must be set before the JVM starts):
;;   -Djdk.attach.allowAttachSelf          (required by both libraries)
;;
;; The :profiling alias includes these flags in :jvm-opts, but if Cursive
;; does not honor alias-provided JVM opts, add them manually to your REPL
;; run configuration's "JVM Args" field.
;;
;; For clj-memory-meter on JDK 17+, you may also need:
;;   --add-opens java.base/java.util=ALL-UNNAMED
;;   --add-opens java.base/java.lang=ALL-UNNAMED
;; (see clj-memory-meter README for the full list if you hit errors)
;; ---------------------------------------------------------------------------

(comment
  ;; -- Require profiling libs (evaluate ONCE before memory/alloc benchmarks) --
  (require '[clj-memory-meter.core :as mm])
  (require '[clj-async-profiler.core :as prof])

  ;; Verify they loaded:
  (println "clj-memory-meter loaded:" (mm/measure "hello"))
  (println "clj-async-profiler loaded:" (some? (resolve 'clj-async-profiler.core/start)))
  )

;; ---------------------------------------------------------------------------
;; 5. Correctness checks
;; ---------------------------------------------------------------------------

(defn assert-rfmk-correctness!
  "Verify lang/rfmk produces correct results.
   NOTE: lang/rfmk now transforms ALL keys (not just strings and simple keywords)
   via explicit recursion + update-keys/update-vals. It will differ from rfmk-old
   on maps with qualified keywords or non-keyword/string keys.
   We compare against rfmk-old only for cases where the old type guard has no effect
   (i.e. all keys are simple keywords or strings), and verify the new behavior directly
   for cases where the old guard would have skipped keys."
  []
  ;; flat map with simple keyword keys -- old and new should agree
  (let [m (gen-flat-map 50)]
    (assert (= (rfmk-old m name) (lang/rfmk m name))
            "rfmk: flat map mismatch"))
  ;; nested map with simple keyword keys -- old and new should agree
  (let [m (gen-nested-map 5 3)]
    (assert (= (rfmk-old m name) (lang/rfmk m name))
            "rfmk: nested map mismatch"))
  ;; map with qualified keywords -- lang/rfmk transforms ALL keys
  (let [m {:a/b 1 :c 2 "d" 3}]
    ;; rfmk-old skips :a/b, lang/rfmk transforms it
    (assert (= (lang/rfmk m name) {"b" 1 "c" 2 "d" 3})
            "rfmk: should transform all keys including qualified keywords"))

  ;; ---------- maps inside vectors ----------
  ;; rfmk-old uses postwalk, lang/rfmk uses explicit recursion -- both walk
  ;; into vectors, so should agree when using simple keys
  (let [m {:a [{:b 1 :c {:d 2}} {:e 3}] :f 4}]
    (assert (= (rfmk-old m name) (lang/rfmk m name))
            "rfmk: maps-inside-vectors mismatch"))

  ;; ---------- maps inside a list ----------
  (let [m {:items (list {:x 10} {:y 20})}]
    (assert (= (lang/rfmk m name)
               {"items" (list {"x" 10} {"y" 20})})
            "rfmk: maps inside lists"))

  ;; ---------- maps inside a set ----------
  (let [m {:items #{{:x 1}}}]
    (assert (= (lang/rfmk m name)
               {"items" #{{"x" 1}}})
            "rfmk: maps inside sets"))

  ;; ---------- deeply nested: map -> vector -> map -> vector -> map ----------
  (let [m {:a [{:b [{:c 1}]}]}]
    (assert (= (lang/rfmk m name)
               {"a" [{"b" [{"c" 1}]}]})
            "rfmk: map-vector-map-vector-map"))

  ;; ---------- mixed: vector of maps alongside plain values ----------
  (let [m {:nums    [1 2 3]
           :records [{:val 10} {:val 20}]
           :nested  {:deep [{:leaf 100}]}}]
    (assert (= (lang/rfmk m name)
               {"nums"    [1 2 3]
                "records" [{"val" 10} {"val" 20}]
                "nested"  {"deep" [{"leaf" 100}]}})
            "rfmk: mixed vectors of maps and plain values"))

  (println "Correctness: lang/rfmk OK (transforms all keys, explicit recursion reaches all collection types)"))

(defn assert-rfmv-correctness!
  "Verify lang/rfmv produces correct results.
   NOTE: lang/rfmv now uses explicit recursion with update-vals, so it reaches
   maps inside vectors, sets, and lists -- unlike rfmv-old which only recursed
   into direct map values. We compare against rfmv-old where they agree (pure
   maps-of-maps) and verify the new deep-walk behavior directly."
  []
  ;; flat map -- old and new should agree
  (let [m (gen-flat-map 50)]
    (assert (= (rfmv-old m inc) (lang/rfmv m inc))
            "rfmv: flat map mismatch"))
  ;; nested map-of-maps -- old and new should agree
  (let [m (gen-nested-map 5 3)]
    (assert (= (rfmv-old m inc) (lang/rfmv m inc))
            "rfmv: nested map mismatch"))
  ;; map with mixed value types -- old and new should agree
  (let [m {:a 1 :b {:c 2 :d {:e 3}} :f 4}]
    (assert (= (rfmv-old m inc) (lang/rfmv m inc))
            "rfmv: mixed nesting mismatch"))

  ;; ---------- maps inside vectors ----------
  ;; rfmv-old would apply f to the vector itself (boom or wrong result).
  ;; lang/rfmv walks into the vector and transforms the maps inside it.
  (let [m {:items [{:x 1 :y 2} {:x 3 :y 4}]}]
    (assert (= (lang/rfmv m inc)
               {:items [{:x 2 :y 3} {:x 4 :y 5}]})
            "rfmv: maps inside vectors"))

  ;; ---------- maps inside a list ----------
  (let [m {:items (list {:x 10} {:x 20})}]
    (assert (= (lang/rfmv m inc)
               {:items (list {:x 11} {:x 21})})
            "rfmv: maps inside lists"))

  ;; ---------- maps inside a set ----------
  ;; sets of maps are uncommon but postwalk handles them
  (let [m {:items #{{:x 1}}}]
    (assert (= (lang/rfmv m inc)
               {:items #{{:x 2}}})
            "rfmv: maps inside sets"))

  ;; ---------- deeply nested: map -> vector -> map -> vector -> map ----------
  (let [m {:a [{:b [{:c 1}]}]}]
    (assert (= (lang/rfmv m inc)
               {:a [{:b [{:c 2}]}]})
            "rfmv: map-vector-map-vector-map"))

  ;; ---------- mixed: vector of maps alongside plain values ----------
  (let [m {:nums    [1 2 3]
           :records [{:val 10} {:val 20}]
           :nested  {:deep [{:leaf 100}]}}]
    (assert (= (lang/rfmv m inc)
               {:nums    [2 3 4]
                :records [{:val 11} {:val 21}]
                :nested  {:deep [{:leaf 101}]}})
            "rfmv: mixed vectors of maps and plain values"))

  (println "Correctness: lang/rfmv OK (explicit recursion reaches maps inside all collection types)"))

(comment
  ;; -- Run these first --
  (assert-rfmk-correctness!)
  (assert-rfmv-correctness!)
  )

;; ---------------------------------------------------------------------------
;; 6. Time benchmarks -- flat maps
;; ---------------------------------------------------------------------------

(defn run-flat-time-bench
  "Run time benchmarks for rfmk/rfmv on a flat (non-nested) map."
  [n & {:keys [iterations] :or {iterations 1000}}]
  (let [m  (gen-flat-map n)
        kf name
        vf inc]
    (println (format "\n=== Flat map: %,d entries | %,d iterations ===" n iterations))

    (println "\n--- rfmk (keys transformation) ---")
    (let [old-result (bench #(rfmk-old m kf) iterations)
          new-result (bench #(lang/rfmk m kf) iterations)
          speedup    (double (/ (:mean-ns old-result)
                                (:mean-ns new-result)))]
      (println (format "  rfmk-old   mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns old-result) (:median-ns old-result) (:min-ns old-result)))
      (println (format "  lang/rfmk  mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns new-result) (:median-ns new-result) (:min-ns new-result)))
      (println (format "  -> lang/rfmk is %.2fx faster" speedup)))

    (println "\n--- rfmv (values transformation) ---")
    (let [old-result (bench #(rfmv-old m vf) iterations)
          new-result (bench #(lang/rfmv m vf) iterations)
          speedup    (double (/ (:mean-ns old-result)
                                (:mean-ns new-result)))]
      (println (format "  rfmv-old   mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns old-result) (:median-ns old-result) (:min-ns old-result)))
      (println (format "  lang/rfmv  mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns new-result) (:median-ns new-result) (:min-ns new-result)))
      (println (format "  -> lang/rfmv is %.2fx faster" speedup)))))

(comment
  ;; -- Flat map time benchmarks --
  (doseq [n flat-sizes]
    (run-flat-time-bench n :iterations (if (>= n 10000) 100 1000)))
  ;;
  ;; === Flat map: 10 entries | 1,000 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:      4,169 ns  |  median:      4,042 ns  |  min:      3,917 ns
  ;;   lang/rfmk  mean:      1,717 ns  |  median:      1,708 ns  |  min:      1,625 ns
  ;;   -> lang/rfmk is 2.43x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:      1,412 ns  |  median:      1,250 ns  |  min:      1,166 ns
  ;;   lang/rfmv  mean:        852 ns  |  median:        792 ns  |  min:        708 ns
  ;;   -> lang/rfmv is 1.66x faster
  ;;
  ;; === Flat map: 100 entries | 1,000 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:     42,102 ns  |  median:     42,458 ns  |  min:     29,500 ns
  ;;   lang/rfmk  mean:      6,836 ns  |  median:      6,500 ns  |  min:      5,417 ns
  ;;   -> lang/rfmk is 6.16x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:      7,072 ns  |  median:      7,042 ns  |  min:      5,750 ns
  ;;   lang/rfmv  mean:      2,941 ns  |  median:      2,917 ns  |  min:      2,666 ns
  ;;   -> lang/rfmv is 2.40x faster
  ;;
  ;; === Flat map: 1,000 entries | 1,000 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:    300,902 ns  |  median:    302,333 ns  |  min:    276,750 ns
  ;;   lang/rfmk  mean:     98,010 ns  |  median:     98,333 ns  |  min:     88,292 ns
  ;;   -> lang/rfmk is 3.07x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:    104,948 ns  |  median:    104,250 ns  |  min:     95,916 ns
  ;;   lang/rfmv  mean:     40,714 ns  |  median:     40,500 ns  |  min:     37,542 ns
  ;;   -> lang/rfmv is 2.58x faster
  ;;
  ;; === Flat map: 10,000 entries | 100 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:  3,109,670 ns  |  median:  3,046,542 ns  |  min:  2,944,875 ns
  ;;   lang/rfmk  mean:    928,476 ns  |  median:    926,584 ns  |  min:    887,083 ns
  ;;   -> lang/rfmk is 3.35x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:    793,605 ns  |  median:    793,333 ns  |  min:    768,958 ns
  ;;   lang/rfmv  mean:    353,871 ns  |  median:    353,292 ns  |  min:    340,958 ns
  ;;   -> lang/rfmv is 2.24x faster
  ;; => nil
  )

;; ---------------------------------------------------------------------------
;; 7. Time benchmarks -- nested maps
;; ---------------------------------------------------------------------------

(defn run-nested-time-bench
  "Run time benchmarks for rfmk/rfmv on a nested map."
  [breadth depth description & {:keys [iterations] :or {iterations 1000}}]
  (let [m     (gen-nested-map breadth depth)
        total (count-entries m)
        kf    name
        vf    inc]
    (println (format "\n=== Nested map: breadth=%d depth=%d (%s, %,d total entries) | %,d iterations ==="
                     breadth depth description total iterations))

    (println "\n--- rfmk (keys transformation) ---")
    (let [old-result (bench #(rfmk-old m kf) iterations)
          new-result (bench #(lang/rfmk m kf) iterations)
          speedup    (double (/ (:mean-ns old-result)
                                (:mean-ns new-result)))]
      (println (format "  rfmk-old   mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns old-result) (:median-ns old-result) (:min-ns old-result)))
      (println (format "  lang/rfmk  mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns new-result) (:median-ns new-result) (:min-ns new-result)))
      (println (format "  -> lang/rfmk is %.2fx faster" speedup)))

    (println "\n--- rfmv (values transformation) ---")
    (let [old-result (bench #(rfmv-old m vf) iterations)
          new-result (bench #(lang/rfmv m vf) iterations)
          speedup    (double (/ (:mean-ns old-result)
                                (:mean-ns new-result)))]
      (println (format "  rfmv-old   mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns old-result) (:median-ns old-result) (:min-ns old-result)))
      (println (format "  lang/rfmv  mean: %,10d ns  |  median: %,10d ns  |  min: %,10d ns"
                       (:mean-ns new-result) (:median-ns new-result) (:min-ns new-result)))
      (println (format "  -> lang/rfmv is %.2fx faster" speedup)))))

(comment
  ;; -- Nested map time benchmarks --
  (doseq [[breadth depth desc] nested-configs]
    (run-nested-time-bench breadth depth desc
                           :iterations (if (>= (* (Math/pow breadth depth) breadth) 5000)
                                         100
                                         1000)))
  ;;
  ;; === Nested map: breadth=5 depth=3 (5^3 = 125 leaves, 155 total entries) | 1,000 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:     41,653 ns  |  median:     41,417 ns  |  min:     36,125 ns
  ;;   lang/rfmk  mean:     13,394 ns  |  median:     11,917 ns  |  min:     10,500 ns
  ;;   -> lang/rfmk is 3.11x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:      9,281 ns  |  median:      9,333 ns  |  min:      7,000 ns
  ;;   lang/rfmv  mean:      4,836 ns  |  median:      4,792 ns  |  min:      4,625 ns
  ;;   -> lang/rfmv is 1.92x faster
  ;;
  ;; === Nested map: breadth=10 depth=3 (10^3 = 1,000 leaves, 1,110 total entries) | 100 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:    328,596 ns  |  median:    326,917 ns  |  min:    317,125 ns
  ;;   lang/rfmk  mean:    107,058 ns  |  median:    106,708 ns  |  min:    104,209 ns
  ;;   -> lang/rfmk is 3.07x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:     77,684 ns  |  median:     77,083 ns  |  min:     72,625 ns
  ;;   lang/rfmv  mean:     36,375 ns  |  median:     35,625 ns  |  min:     35,208 ns
  ;;   -> lang/rfmv is 2.14x faster
  ;;
  ;; === Nested map: breadth=5 depth=4 (5^4 = 625 leaves, 780 total entries) | 1,000 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:    210,037 ns  |  median:    209,000 ns  |  min:    191,250 ns
  ;;   lang/rfmk  mean:     61,327 ns  |  median:     61,250 ns  |  min:     56,375 ns
  ;;   -> lang/rfmk is 3.42x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:     50,920 ns  |  median:     49,791 ns  |  min:     43,917 ns
  ;;   lang/rfmv  mean:     27,611 ns  |  median:     27,500 ns  |  min:     25,375 ns
  ;;   -> lang/rfmv is 1.84x faster
  ;;
  ;; === Nested map: breadth=10 depth=2 (10^2 = 100 leaves, 110 total entries) | 1,000 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:     33,302 ns  |  median:     33,083 ns  |  min:     30,500 ns
  ;;   lang/rfmk  mean:     13,238 ns  |  median:     13,542 ns  |  min:      9,833 ns
  ;;   -> lang/rfmk is 2.52x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:      7,681 ns  |  median:      7,708 ns  |  min:      6,542 ns
  ;;   lang/rfmv  mean:      3,524 ns  |  median:      3,500 ns  |  min:      3,417 ns
  ;;   -> lang/rfmv is 2.18x faster
  ;;
  ;; === Nested map: breadth=20 depth=2 (20^2 = 400 leaves, 420 total entries) | 100 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:    121,649 ns  |  median:    120,875 ns  |  min:    116,333 ns
  ;;   lang/rfmk  mean:     37,034 ns  |  median:     36,875 ns  |  min:     34,833 ns
  ;;   -> lang/rfmk is 3.28x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:     30,145 ns  |  median:     30,084 ns  |  min:     28,500 ns
  ;;   lang/rfmv  mean:     17,471 ns  |  median:     17,500 ns  |  min:     13,583 ns
  ;;   -> lang/rfmv is 1.73x faster
  ;;
  ;; === Nested map: breadth=3 depth=5 (3^5 = 243 leaves, 363 total entries) | 1,000 iterations ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old   mean:    104,036 ns  |  median:    103,000 ns  |  min:     92,667 ns
  ;;   lang/rfmk  mean:     33,036 ns  |  median:     32,709 ns  |  min:     31,166 ns
  ;;   -> lang/rfmk is 3.15x faster
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old   mean:     29,261 ns  |  median:     28,542 ns  |  min:     22,250 ns
  ;;   lang/rfmv  mean:     18,472 ns  |  median:     17,333 ns  |  min:     15,459 ns
  ;;   -> lang/rfmv is 1.58x faster
  ;; => nil
  )

;; ---------------------------------------------------------------------------
;; 8. Memory benchmarks -- retained size (clj-memory-meter)
;; ---------------------------------------------------------------------------

(defn run-retained-size-bench
  "Compare retained heap size of old vs new implementations.
   Requires clj-memory-meter to be loaded (see section 4)."
  [breadth depth description]
  (require '[clj-memory-meter.core :as mm])
  (let [mm-measure (resolve 'clj-memory-meter.core/measure)
        m          (gen-nested-map breadth depth)
        total      (count-entries m)
        kf         name
        vf         inc]
    (println (format "\n=== Retained size | breadth=%d depth=%d (%s, %,d total entries) ==="
                     breadth depth description total))

    (println "\n--- rfmk (keys transformation) ---")
    (let [old-result (rfmk-old m kf)
          new-result (lang/rfmk m kf)
          old-bytes  (mm-measure old-result :bytes true)
          new-bytes  (mm-measure new-result :bytes true)]
      (println (format "  rfmk-old  result: %s (%,d bytes)"
                       (mm-measure old-result) old-bytes))
      (println (format "  lang/rfmk result: %s (%,d bytes)"
                       (mm-measure new-result) new-bytes))
      (if (= old-bytes new-bytes)
        (println "  -> Same retained size")
        (println (format "  -> Ratio: %.2fx" (double (/ old-bytes new-bytes))))))

    (println "\n--- rfmv (values transformation) ---")
    (let [old-result (rfmv-old m vf)
          new-result (lang/rfmv m vf)
          old-bytes  (mm-measure old-result :bytes true)
          new-bytes  (mm-measure new-result :bytes true)]
      (println (format "  rfmv-old  result: %s (%,d bytes)"
                       (mm-measure old-result) old-bytes))
      (println (format "  lang/rfmv result: %s (%,d bytes)"
                       (mm-measure new-result) new-bytes))
      (if (= old-bytes new-bytes)
        (println "  -> Same retained size")
        (println (format "  -> Ratio: %.2fx" (double (/ old-bytes new-bytes))))))))

(comment
  ;; -- Retained size benchmarks --
  ;; NOTE: Run section 4 first to load clj-memory-meter.
  (doseq [[breadth depth desc] nested-configs]
    (run-retained-size-bench breadth depth desc))
  ;;
  ;; === Retained size | breadth=5 depth=3 (5^3 = 125 leaves, 155 total entries) ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old  result: 3.0 KiB (3,088 bytes)
  ;;   lang/rfmk result: 3.0 KiB (3,088 bytes)
  ;;   -> Same retained size
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old  result: 3.3 KiB (3,368 bytes)
  ;;   lang/rfmv result: 3.3 KiB (3,368 bytes)
  ;;   -> Same retained size
  ;;
  ;; === Retained size | breadth=10 depth=3 (10^3 = 1,000 leaves, 1,110 total entries) ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old  result: 21.5 KiB (22,032 bytes)
  ;;   lang/rfmk result: 21.5 KiB (22,032 bytes)
  ;;   -> Same retained size
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old  result: 29.9 KiB (30,584 bytes)
  ;;   lang/rfmv result: 27.3 KiB (27,920 bytes)
  ;;   -> Ratio: 1.10x
  ;;
  ;; === Retained size | breadth=5 depth=4 (5^4 = 625 leaves, 780 total entries) ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old  result: 13.8 KiB (14,088 bytes)
  ;;   lang/rfmk result: 13.8 KiB (14,088 bytes)
  ;;   -> Same retained size
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old  result: 14.0 KiB (14,368 bytes)
  ;;   lang/rfmv result: 14.0 KiB (14,368 bytes)
  ;;   -> Same retained size
  ;;
  ;; === Retained size | breadth=10 depth=2 (10^2 = 100 leaves, 110 total entries) ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old  result: 2.8 KiB (2,832 bytes)
  ;;   lang/rfmk result: 2.8 KiB (2,832 bytes)
  ;;   -> Same retained size
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old  result: 4.1 KiB (4,184 bytes)
  ;;   lang/rfmv result: 3.8 KiB (3,920 bytes)
  ;;   -> Ratio: 1.07x
  ;;
  ;; === Retained size | breadth=20 depth=2 (20^2 = 400 leaves, 420 total entries) ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old  result: 13.2 KiB (13,536 bytes)
  ;;   lang/rfmk result: 13.2 KiB (13,536 bytes)
  ;;   -> Same retained size
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old  result: 14.5 KiB (14,824 bytes)
  ;;   lang/rfmv result: 13.7 KiB (13,984 bytes)
  ;;   -> Ratio: 1.06x
  ;;
  ;; === Retained size | breadth=3 depth=5 (3^5 = 243 leaves, 363 total entries) ===
  ;;
  ;; --- rfmk (keys transformation) ---
  ;;   rfmk-old  result: 8.7 KiB (8,928 bytes)
  ;;   lang/rfmk result: 8.7 KiB (8,928 bytes)
  ;;   -> Same retained size
  ;;
  ;; --- rfmv (values transformation) ---
  ;;   rfmv-old  result: 8.9 KiB (9,096 bytes)
  ;;   lang/rfmv result: 8.9 KiB (9,096 bytes)
  ;;   -> Same retained size
  ;; => nil
  )

;; ---------------------------------------------------------------------------
;; 9. Allocation profiling (clj-async-profiler)
;; ---------------------------------------------------------------------------

(defn run-alloc-profile-rfmk
  "Generate an allocation flamegraph comparing rfmk-old vs lang/rfmk.
   Requires clj-async-profiler to be loaded (see section 4)."
  [breadth depth iterations]
  (require '[clj-async-profiler.core :as prof])
  (let [start (resolve 'clj-async-profiler.core/start)
        stop  (resolve 'clj-async-profiler.core/stop)
        m     (gen-nested-map breadth depth)]
    (println (format "Profiling allocation: rfmk old vs new | breadth=%d depth=%d | %,d iterations"
                     breadth depth iterations))
    (start {:event :alloc
            :title (format "rfmk old vs new (breadth=%d depth=%d)" breadth depth)})
    (dotimes [_ iterations]
      (rfmk-old m name)
      (lang/rfmk m name))
    (stop)))

(defn run-alloc-profile-rfmv
  "Generate an allocation flamegraph comparing rfmv-old vs lang/rfmv.
   Requires clj-async-profiler to be loaded (see section 4)."
  [breadth depth iterations]
  (require '[clj-async-profiler.core :as prof])
  (let [start (resolve 'clj-async-profiler.core/start)
        stop  (resolve 'clj-async-profiler.core/stop)
        m     (gen-nested-map breadth depth)]
    (println (format "Profiling allocation: rfmv old vs new | breadth=%d depth=%d | %,d iterations"
                     breadth depth iterations))
    (start {:event :alloc
            :title (format "rfmv old vs new (breadth=%d depth=%d)" breadth depth)})
    (dotimes [_ iterations]
      (rfmv-old m inc)
      (lang/rfmv m inc))
    (stop)))

(comment
  ;; -- rfmk allocation flamegraph --
  (run-alloc-profile-rfmk 10 3 5000)

  ;; -- rfmv allocation flamegraph --
  (run-alloc-profile-rfmv 10 3 5000)

  ;; browse flamegraphs at http://localhost:8080
  ((resolve 'clj-async-profiler.core/serve-ui) 8080)
  (.exec (Runtime/getRuntime) "open http://localhost:8080")
  )

;; ---------------------------------------------------------------------------
;; 10. Full suite
;; ---------------------------------------------------------------------------

(defn run-all!
  "Run correctness checks and time benchmarks for both flat and nested maps.
   Allocation flamegraphs are run separately (see section 9 comment blocks)."
  []
  (assert-rfmk-correctness!)
  (assert-rfmv-correctness!)

  (println "\n" (apply str (repeat 70 "="))
           "\n FLAT MAP TIME BENCHMARKS"
           "\n" (apply str (repeat 70 "=")))
  (doseq [n flat-sizes]
    (run-flat-time-bench n :iterations (if (>= n 10000) 100 1000)))

  (println "\n" (apply str (repeat 70 "="))
           "\n NESTED MAP TIME BENCHMARKS"
           "\n" (apply str (repeat 70 "=")))
  (doseq [[breadth depth desc] nested-configs]
    (run-nested-time-bench breadth depth desc
                           :iterations (if (>= (* (Math/pow breadth depth) breadth) 5000)
                                         100
                                         1000)))

  (println "\n" (apply str (repeat 70 "="))
           "\n DONE"
           "\n" (apply str (repeat 70 "="))
           "\n"
           "\n For retained-size benchmarks, run section 8 (requires clj-memory-meter)."
           "\n For allocation flamegraphs, run section 9 (requires clj-async-profiler)."))

(comment
  ;; -- Run the full suite --
  (run-all!)
  )

;; ---------------------------------------------------------------------------
;; 11. Why the optimized versions are faster
;; ---------------------------------------------------------------------------
;;
;; rfmk-old:
;;   Uses postwalk + (into {} (map fun x)) where `fun` destructures [[k v]],
;;   checks (string? k) or (simple-keyword? k), and allocates a temporary
;;   vector per entry plus an intermediate lazy seq.
;;   The type guard also means qualified keywords and non-keyword/string keys
;;   are silently skipped -- an unintentional limitation.
;;
;; lang/rfmk (current):
;;   Explicit recursion via letfn + cond dispatch, no postwalk:
;;     (letfn [(walk [x]
;;               (cond
;;                 (map? x)        (update-keys (update-vals x walk) f)
;;                 (vector? x)     (mapv walk x)
;;                 (set? x)        (into #{} (map walk) x)
;;                 (sequential? x) (map walk x)
;;                 :else           x))]
;;       (update-keys (update-vals m walk) f))
;;
;;   Why this is faster:
;;   - No postwalk overhead: walks only into values to find nested maps,
;;     not every node in the tree. Applies f directly to keys via update-keys.
;;   - update-keys / update-vals (Clojure 1.11+) use reduce-kv + transients
;;     internally -- same perf as hand-rolled reduce-kv but cleaner.
;;   - No destructuring: no temporary vector allocation per map entry.
;;   - No type guard: f is applied to every key unconditionally.
;;   - Walks into vectors, sets, and sequences to reach maps nested inside
;;     any collection type (unlike postwalk, the dispatch is explicit and
;;     avoids rebuilding non-map collections unnecessarily).
;;
;; rfmv-old:
;;   Used explicit recursion with into + map transducer + destructuring:
;;     (into {} (map (fn [[k v]] [k (if (map? v) (rfmv-old v f) (f v))])) m)
;;   - Only recurses into direct map values; maps nested inside vectors,
;;     sets, or lists are NOT reached (f is applied to the collection itself)
;;   - Destructures [k v] from each MapEntry + allocates a temporary vector
;;     per entry
;;
;; lang/rfmv (current):
;;   Symmetric explicit recursion via letfn + cond dispatch, no postwalk:
;;     (letfn [(walk [x]
;;               (cond
;;                 (map? x)        (update-vals x walk)
;;                 (vector? x)     (mapv walk x)
;;                 (set? x)        (into #{} (map walk) x)
;;                 (sequential? x) (map walk x)
;;                 :else           (f x)))]
;;       (update-vals m walk))
;;
;;   Why this is faster:
;;   - No postwalk: explicit cond dispatch only processes the types we care
;;     about, avoiding the overhead of walk/postwalk's generic traversal.
;;   - update-vals uses reduce-kv + transients internally, and starts from
;;     (transient m) preserving structural sharing with the original map.
;;   - No destructuring: no temporary vector allocation per map entry.
;;   - f is applied only to leaf values (non-collection). The cond dispatch
;;     naturally separates "recurse into containers" from "transform leaves."
;;   - Walks into vectors, sets, and sequences to reach maps nested inside
;;     any collection type (fixes the rfmv-old bug).
;;
;; ---------------------------------------------------------------------------
;; Benchmark results summary
;; ---------------------------------------------------------------------------
;;
;; Timing (wall-clock):
;;   rfmk: 2.4-6.2x faster (larger gains at higher entry counts)
;;   rfmv: 1.6-2.6x faster (consistent across sizes)
;;
;; Allocation profiling (clj-async-profiler, breadth=10 depth=3):
;;   rfmk: old accounted for 89% of allocations, new for 11% (~8:1 ratio)
;;   rfmv: old accounted for 86% of allocations, new for 14% (~6:1 ratio)
;;
;;   Both functions eliminate the same waste: temporary [k v] vectors from
;;   destructuring, lazy seq machinery from (map ...), and postwalk's generic
;;   (into (empty form) (map inner form)) on every collection node.
;;
;; Why rfmk's speedup is larger than rfmv's despite similar allocation ratios:
;;   The allocation ratios are comparable (8:1 vs 6:1), yet rfmk sees a
;;   steeper wall-clock improvement (3-6x vs 1.6-2.4x). This is because
;;   rfmk's per-entry useful work is heavier -- transforming a key requires
;;   rehashing and finding its slot in the new HAMT -- so the garbage overhead
;;   represented a larger fraction of total time. Eliminating it has more
;;   impact. For rfmv, f (inc on integers) is trivially cheap, so the useful
;;   work (update-vals rebuilding trie nodes) was already a significant portion
;;   of old rfmv's runtime. Removing the garbage helps, but the irreducible
;;   work dilutes the speedup. In effect, old rfmv was less wasteful in
;;   relative terms despite allocating similar amounts of garbage in absolute
;;   terms.
;;
;; Retained size (clj-memory-meter):
;;   rfmk: identical retained size in all configurations. Both old and new
;;     produce the same output structure -- every key is transformed, so no
;;     HAMT nodes can be shared with the input.
;;   rfmv: identical or slightly smaller (6-10% at breadth >= 10). update-vals
;;     starts from (transient m) -- the original map's trie -- so it can reuse
;;     internal HAMT nodes. (into {} ...) builds from an empty transient, so
;;     the trie is reconstructed from scratch with potentially different
;;     internal structure. The savings only appear at breadth >= 10 because
;;     smaller maps (< 9 entries) use PersistentArrayMap (flat array, no trie)
;;     and have no internal nodes to share.
;; ---------------------------------------------------------------------------
```

Performance
-----------

Benchmarked across flat maps (10-10,000 entries) and nested maps (various breadth/depth configurations from 100 to 1,100 total entries).

 ### Wall-clock timing:

  - `rfmk`: 2.4-6.2x faster (larger gains at higher entry counts)
  - `rfmv`: 1.6-2.6x faster (consistent across sizes)

 ### Allocation profiling (clj-async-profiler, breadth=10 depth=3):

  - `rfmk`: old accounted for 89% of allocations, new for 11% (~8:1)
  - `rfmv`: old accounted for 86% of allocations, new for 14% (~6:1)

 ### The allocation reduction comes from eliminating three sources of garbage:

  1. Temporary `[k v]` vectors from MapEntry destructuring (2 per entry)
  2. Lazy seq machinery from `(map ...)` intermediates
  3. `postwalk`'s generic `(into (empty form) (map inner form))` rebuild of every collection node (previous versions)

`rfmk` sees a steeper wall-clock improvement despite similar allocation ratios because its per-entry useful work is heavier -- transforming a key requires rehashing and HAMT slot lookup. For `rfmv`, the transform function (`inc` on integers) is trivially cheap, so the irreducible work of rebuilding trie nodes was already a significant fraction of old `rfmv`'s runtime.

Retained size (clj-memory-meter):

  - `rfmk`: identical in all configurations (every key changes, so no HAMT nodes can be shared with the input regardless of implementation)
  - `rfmv`: identical or 6-10% smaller at breadth >= 10, because `update-vals` starts from `(transient m)` (preserving the original map's trie structure) while `(into {} ...)` builds from an empty transient

Deprecations
------------

`fmk` and `fmv` (added in 0.1.0) are thin wrappers that are now redundant with `clojure.core/update-keys` and `clojure.core/update-vals` (available since Clojure 1.11). Both are marked `:deprecated "0.1.51"` (the presumed next release version) and their bodies delegate directly to the core functions.