### PR TITLE
Fix group-by-ns: convert sequence to map before key transformation

### DIFF
--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -471,6 +471,7 @@
        :b {:one :b-one, :two :b-two}}"
   [m]
   (-> (group-by (comp namespace key) m)
+      (fmv #(into {} %))
       (fmk keyword)
       (fmv #(fmk % (comp keyword name)))))
 


### PR DESCRIPTION
## Problem
The `group-by-ns` function was failing with error: 

```
(y/group-by-ns {:a/one :a-one :b/one :b-one :a/two :a-two :b/two :b-two})
; Execution error (ClassCastException) at yang.lang/fmk (lang.clj:55).
; class java.lang.Integer cannot be cast to class clojure.lang.Named (java.lang.Integer is in module java.base of loader 'bootstrap'; clojure.lang.Named is in unnamed module of loader 'app')
```

## Root Cause
The `group-by` built-in returns a map with sequences as values (not maps):
```clojure
{:a [:a/one :a-one :a/two :a-two]
 :b [:b/one :b-one :b/two :b-two]}
```

When `fmk` tried to transform keys on these sequences, it attempted to apply keyword to integer indices (sequence indices), which cannot be cast to Named types.

## Solution

Added `(fmv #(into {} %))` transformation to convert each grouped sequence into a map before applying key transformations. This ensures `fmk` operates on actual maps with keyword keys, not sequences with integer indices.

```
(y/group-by-ns {:a/one :a-one :b/one :b-one :a/two :a-two :b/two :b-two})
{:a {:one :a-one, :two :a-two}, :b {:one :b-one, :two :b-two}}
```

## Files Changed
- `src/yang/lang.clj`: Added sequence-to-map conversion in group-by-ns function 
