### PR TITLE
Improve "deep-merge-with" function to handle nil values gracefully

### DIFF
--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -514,11 +514,13 @@
    -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}"
   [f & maps]
   (apply
-    (fn m [& maps]
-      (if (every? map? maps)
-        (apply merge-with m maps)
-        (apply f maps)))
-    maps))
+   (fn m [& maps]
+     (let [maps (remove nil? maps)]     ;; nil is "nothing to merge", not a value for f
+       (cond
+         (every? map? maps) (apply merge-with m maps)
+         (seq maps)          (apply f maps)
+         :else               nil)))
+   maps))
 
 (defn remove-deep [key-set data]
   "from https://stackoverflow.com/a/52041784/114359

--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -440,6 +440,20 @@
           (when-not (none? k)
             [k v]))))
 
+(defn remove-nil-keys
+  "recursively drops nil-valued keys at every level, keeping false/empty/zero values intact
+   use this before merge-maps/deep-merge-with if nil should mean 'absent' instead of an override value
+
+   => (remove-nil-keys {:a 1 :b nil :c {:d 1 :e nil}})
+      {:a 1, :c {:d 1}}"
+  [m]
+  (walk/postwalk
+   (fn [x]
+     (if (map? x)
+       (into {} (remove (comp nil? val)) x)
+       x))
+   m))
+
 (defn props->map
   "java.util.Properties to map"
   [props]
@@ -513,14 +527,11 @@
                 {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
    -> {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}"
   [f & maps]
-  (apply
-   (fn m [& maps]
-     (let [maps (remove nil? maps)]     ;; nil is "nothing to merge", not a value for f
-       (cond
-         (every? map? maps) (apply merge-with m maps)
-         (seq maps)          (apply f maps)
-         :else               nil)))
-   maps))
+  (letfn [(merge-level [& values]
+            (if (every? map? values)
+              (apply merge-with merge-level values)
+              (apply f values)))]
+    (apply merge-with merge-level maps)))
 
 (defn remove-deep [key-set data]
   "from https://stackoverflow.com/a/52041784/114359

--- a/test/yang/test/lang.clj
+++ b/test/yang/test/lang.clj
@@ -124,3 +124,26 @@
     (is (= 0.000001 (y/parse-number "0.000001")))
     (is (= 0.123456789 (y/parse-number "0.123456789")))))
 
+
+(deftest should-merge-nil-values-consistently
+  (testing "nil map arguments are ignored"
+    (is (= {:a 1}
+           (y/merge-maps {:a 1} nil)))
+    (is (= {:a 3 :b 2}
+           (y/merge-maps {:a 1 :b 2} nil {:a 3}))))
+
+  (testing "explicit nil values are preserved"
+    (is (= {:a nil}
+           (y/merge-maps {:a 1} {:a nil})))
+    (is (= {:a 3}
+           (y/merge-maps {:a 1} {:a nil} {:a 3})))
+    (is (= {:a 1}
+           (y/deep-merge-with (fnil + 0 0)
+                              {:a 1}
+                              {:a nil}))))
+
+  (testing "nil keys can be removed before merging"
+    (is (= {:a 1}
+           (y/remove-nil-keys {:a 1 :b nil})))
+    (is (= {:a {:b 1}}
+           (y/remove-nil-keys {:a {:b 1 :c nil}})))))


### PR DESCRIPTION
# Fix `merge-maps` incorrectly returns `nil` when one of the input maps is `nil`

## Summary

`merge-maps` (backed by `deep-merge-with`) in [`src/yang/lang.clj`](src/yang/lang.clj) produced incorrect results whenever one of the maps passed to it was `nil`. Depending on argument position and count, this caused either silent data loss (a valid map being discarded and replaced with `nil`) or a runtime `ArityException`. This PR fixes `deep-merge-with` so `nil` inputs are treated as "nothing to merge" instead of being treated as a mergeable value, while preserving `clojure.core/merge` semantics for explicit `nil` values.

## Background

`merge-maps` is defined as:

```clojure
(defn merge-maps [& m]
  (apply deep-merge-with (fn [_ v] v) m))
```

It delegates to `deep-merge-with`, which recursively merges maps and only calls the supplied function `f` when it encounters a **non-map value** at a given level:

```clojure
(defn deep-merge-with
  [f & maps]
  (apply
    (fn m [& maps]
      (if (every? map? maps)
        (apply merge-with m maps)
        (apply f maps)))
    maps))
```

## Root Cause

The check `(every? map? maps)` decides whether to recurse (`merge-with`) or apply the leaf-merge function `f` directly.

`nil` is **not** a map, so `map?` returns `false` for it. This means that as soon as any argument — top-level or nested — was `nil`, the code treated it exactly like a genuine "conflicting value" and fell into the `(apply f maps)` branch instead of recursing.

This had three separate negative consequences:

1. **Silent data loss (2 args).**
   For `merge-maps`, `f` is `(fn [_ v] v)` — "the second/last value wins." When one of exactly two arguments was `nil` and it landed as the second argument to `f`, the result became `nil`, discarding the perfectly valid first map entirely.

2. **Arity exceptions (3+ args).**
   At the top level, `deep-merge-with` invokes the internal `m` function directly with **all** of the original arguments (not pairwise). If any one of 3+ maps was `nil`, the `every? map?` check failed for the whole group, and `(apply f maps)` was called with 3+ arguments — but `f` only accepts 2. This threw `clojure.lang.ArityException`.

3. **Nested value loss.**
   Even when top-level maps were all non-nil, if a *nested* value under a shared key was `nil` in one map and a map in another, the same logic kicked in and discarded the nested map, replacing it with `nil`.

## Fix

`deep-merge-with` no longer performs any manual `nil` filtering. It relies entirely on `merge-with`'s own native tolerance for `nil` map arguments (the same tolerance `clojure.core/merge` already has), and the conflict-resolving function is only ever invoked by `merge-with`'s own pairwise reduction:

```clojure
(defn deep-merge-with
  [f & maps]
  (letfn [(merge-level [& values]
            (if (every? map? values)
              (apply merge-with merge-level values)
              (apply f values)))]
    (apply merge-with merge-level maps)))
```

Behavior after the fix:

- A `nil` map argument anywhere is ignored, exactly like `clojure.core/merge` already ignores one.
- `merge-level` (the conflict resolver) is only ever called with exactly 2 values, since it's only invoked via `merge-with`'s own reduce — this removes the `ArityException`.
- An explicit `nil` *value* at a key is preserved and can override an existing value, matching `clojure.core/merge` semantics exactly.

## Examples

### Before the fix (original bug)

```clojure
(merge-maps {:a 1} nil)
;; => nil                          ;; BUG: valid map discarded

(merge-maps {:a 1 :b 2} nil {:a 3})
;; => ArityException: Wrong number of args (3) passed to: yang.lang/merge-maps/fn--9792

```

### After the fix

```clojure
(merge-maps {:a 1} nil)
;; => {:a 1}

(merge-maps nil {:a 1})
;; => {:a 1}

(merge-maps {:a 1 :b 2} nil {:a 3})
;; => {:a 3, :b 2}

(merge-maps {:a {:b 1 :c 2}} {:a nil})
;; => {:a nil}                     ;; matches clojure.core/merge exactly

(merge-maps {:a 1} {:a nil} {:a 3})
;; => {:a 3}                       ;; no longer throws ArityException

(deep-merge-with (fnil + 0 0) {:a 1} {:a nil})
;; => {:a 1}

(merge-maps {:a {:b 1}} nil {:a {:c 2}})
;; => {:a {:b 1, :c 2}}

(merge-maps nil nil)
;; => nil                          ;; unchanged, still correct: nothing to merge
```

### Regression check — existing documented behavior still holds

```clojure
(deep-merge-with + {:a {:b {:c 1 :d {:x 1 :y 2}} :e 3} :f 4}
                    {:a {:b {:c 2 :d {:z 9} :z 3} :e 100}})
;; => {:a {:b {:z 3, :c 3, :d {:z 9, :x 1, :y 2}}, :e 103}, :f 4}
```

## Impact

- For the common case — merging real maps with no `nil`s involved — output is byte-identical to `master`, confirmed against the existing recursive `deep-merge-with` docstring example.
- Fixes the reported bug: a `nil` map argument anywhere no longer causes data loss or an `ArityException`.
- Aligns explicit `nil` value handling with `clojure.core/merge`, exactly as requested in review.
- `remove-nil-keys` is new and purely additive — it cannot break any existing caller.

## Verification

- Live-probed `nil` in every position/count, explicit nil overrides, `fnil`, nested nils, non-map args, and mismatched `f` arity in the REPL, cross-checked against a reconstructed copy of the original `master` implementation.
- `clojure -M:test -n yang.test.lang` → 5 tests, 94 assertions, 0 failures, 0 errors.