### PR TITLE
Fix : merge-maps handling of nil map arguments

### DIFF
--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -535,6 +535,30 @@
 (defn merge-maps [& m]
   (apply deep-merge-with (fn [_ v] v) m))
 
+(defn merge-maps-strict
+  "like merge-maps, but treats empty values as absent instead of an override
+   value: nil map arguments are dropped, and empty values (nil, \"\", [], {},
+   reusing remove-empty) are stripped from each map recursively before
+   merging - safe from the arity/data-loss issues merge-maps has when nils
+   are involved, since deep-merge-with never sees a nil
+   assumes every input is a map (or nil)
+
+   => (merge-maps-strict {:a 1} nil)
+      {:a 1}
+
+   => (merge-maps-strict {:a {:b 1 :c 2}} {:a nil})
+      {:a {:b 1, :c 2}}
+
+   => (merge-maps-strict {:a 1} {:a nil} {:a 3})
+      {:a 3}"
+  [& m]
+  (letfn [(clean [x]
+            (remove-empty (update-vals x #(if (map? %) (clean %) %))))]
+    (->> m
+         (remove nil?)
+         (map clean)
+         (apply merge-maps))))
+
 (defn dissoc-in
   "from https://github.com/clojure/core.incubator
 

--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -538,30 +538,6 @@
 (defn merge-maps [& m]
   (apply deep-merge-with (fn [_ v] v) (remove-nil-maps m)))
 
-(defn merge-maps-strict
-  "like merge-maps, but treats empty values as absent instead of an override
-   value: nil map arguments are dropped, and empty values (nil, \"\", [], {},
-   reusing remove-empty) are stripped from each map recursively before
-   merging - safe from the arity/data-loss issues merge-maps has when nils
-   are involved, since deep-merge-with never sees a nil
-   assumes every input is a map (or nil)
-
-   => (merge-maps-strict {:a 1} nil)
-      {:a 1}
-
-   => (merge-maps-strict {:a {:b 1 :c 2}} {:a nil})
-      {:a {:b 1, :c 2}}
-
-   => (merge-maps-strict {:a 1} {:a nil} {:a 3})
-      {:a 3}"
-  [& m]
-  (letfn [(clean [x]
-            (remove-empty (update-vals x #(if (map? %) (clean %) %))))]
-    (->> m
-         (remove nil?)
-         (map clean)
-         (apply merge-maps))))
-
 (defn dissoc-in
   "from https://github.com/clojure/core.incubator
 

--- a/src/yang/lang.clj
+++ b/src/yang/lang.clj
@@ -532,8 +532,11 @@
         node))
     data))
 
+(defn- remove-nil-maps [maps]
+  (remove nil? maps))
+
 (defn merge-maps [& m]
-  (apply deep-merge-with (fn [_ v] v) m))
+  (apply deep-merge-with (fn [_ v] v) (remove-nil-maps m)))
 
 (defn merge-maps-strict
   "like merge-maps, but treats empty values as absent instead of an override

--- a/test/yang/test/lang.clj
+++ b/test/yang/test/lang.clj
@@ -124,3 +124,42 @@
     (is (= 0.000001 (y/parse-number "0.000001")))
     (is (= 0.123456789 (y/parse-number "0.123456789")))))
 
+(deftest should-merge-maps-strict-without-throwing
+  (testing "nil map arguments are dropped instead of causing data loss"
+    (is (= {:a 1}
+           (y/merge-maps-strict {:a 1} nil)))
+    (is (= {:a 1}
+           (y/merge-maps-strict nil {:a 1})))
+    (is (nil? (y/merge-maps-strict nil nil))))
+
+  (testing "does not throw ArityException with 3+ maps when one is nil"
+    (is (= {:a 3 :b 2}
+           (y/merge-maps-strict {:a 1 :b 2} nil {:a 3})))
+    (is (= {:a 3}
+           (y/merge-maps-strict {:a 1} {:a nil} {:a 3})))
+    (is (= {:a {:b 1 :c 2}}
+           (y/merge-maps-strict {:a {:b 1}} nil {:a {:c 2}}))))
+
+  (testing "explicit nil values are treated as absent rather than an override"
+    (is (= {:a {:b 1 :c 2}}
+           (y/merge-maps-strict {:a {:b 1 :c 2}} {:a nil}))))
+
+  (testing "nil-valued keys are dropped at every nesting level"
+    (is (= {:a {:b {:c 1}}}
+           (y/merge-maps-strict {:a {:b {:c 1 :d nil}}}))))
+
+  (testing "keeps false and zero, but drops empty collections/strings too, reusing remove-empty"
+    (is (= {:a false :c 0}
+           (y/merge-maps-strict {:a false :b [] :c 0 :d nil}))))
+
+  (testing "single map argument is returned cleaned, unaffected by merging"
+    (is (= {:a 1}
+           (y/merge-maps-strict {:a 1 :b nil}))))
+
+  (testing "a map that becomes entirely empty after cleaning merges away cleanly"
+    (is (= {} (y/merge-maps-strict {:a nil} {:b nil}))))
+
+  (testing "regression: the original merge-maps bug still reproduces, confirming it was left untouched"
+    (is (nil? (y/merge-maps {:a 1} nil)))
+    (is (thrown? clojure.lang.ArityException
+                 (y/merge-maps {:a 1 :b 2} nil {:a 3})))))

--- a/test/yang/test/lang.clj
+++ b/test/yang/test/lang.clj
@@ -124,45 +124,10 @@
     (is (= 0.000001 (y/parse-number "0.000001")))
     (is (= 0.123456789 (y/parse-number "0.123456789")))))
 
-(deftest should-merge-maps-strict-without-throwing
-  (testing "nil map arguments are dropped instead of causing data loss"
-    (is (= {:a 1}
-           (y/merge-maps-strict {:a 1} nil)))
-    (is (= {:a 1}
-           (y/merge-maps-strict nil {:a 1})))
-    (is (nil? (y/merge-maps-strict nil nil))))
-
-  (testing "does not throw ArityException with 3+ maps when one is nil"
-    (is (= {:a 3 :b 2}
-           (y/merge-maps-strict {:a 1 :b 2} nil {:a 3})))
-    (is (= {:a 3}
-           (y/merge-maps-strict {:a 1} {:a nil} {:a 3})))
-    (is (= {:a {:b 1 :c 2}}
-           (y/merge-maps-strict {:a {:b 1}} nil {:a {:c 2}}))))
-
-  (testing "explicit nil values are treated as absent rather than an override"
-    (is (= {:a {:b 1 :c 2}}
-           (y/merge-maps-strict {:a {:b 1 :c 2}} {:a nil}))))
-
-  (testing "nil-valued keys are dropped at every nesting level"
-    (is (= {:a {:b {:c 1}}}
-           (y/merge-maps-strict {:a {:b {:c 1 :d nil}}}))))
-
-  (testing "keeps false and zero, but drops empty collections/strings too, reusing remove-empty"
-    (is (= {:a false :c 0}
-           (y/merge-maps-strict {:a false :b [] :c 0 :d nil}))))
-
-  (testing "single map argument is returned cleaned, unaffected by merging"
-    (is (= {:a 1}
-           (y/merge-maps-strict {:a 1 :b nil}))))
-
-  (testing "a map that becomes entirely empty after cleaning merges away cleanly"
-    (is (= {} (y/merge-maps-strict {:a nil} {:b nil}))))
-
-  (testing "merge-maps ignores nil map arguments"
-    (is (= {:a 1}
-           (y/merge-maps {:a 1} nil)))
-    (is (= {:a 1}
-           (y/merge-maps nil {:a 1})))
-    (is (= {:a 3 :b 2}
-           (y/merge-maps {:a 1 :b 2} nil {:a 3})))))
+(testing "merge-maps ignores nil map arguments"
+  (is (= {:a 1}
+         (y/merge-maps {:a 1} nil)))
+  (is (= {:a 1}
+         (y/merge-maps nil {:a 1})))
+  (is (= {:a 3 :b 2}
+         (y/merge-maps {:a 1 :b 2} nil {:a 3}))))

--- a/test/yang/test/lang.clj
+++ b/test/yang/test/lang.clj
@@ -159,7 +159,10 @@
   (testing "a map that becomes entirely empty after cleaning merges away cleanly"
     (is (= {} (y/merge-maps-strict {:a nil} {:b nil}))))
 
-  (testing "regression: the original merge-maps bug still reproduces, confirming it was left untouched"
-    (is (nil? (y/merge-maps {:a 1} nil)))
-    (is (thrown? clojure.lang.ArityException
-                 (y/merge-maps {:a 1 :b 2} nil {:a 3})))))
+  (testing "merge-maps ignores nil map arguments"
+    (is (= {:a 1}
+           (y/merge-maps {:a 1} nil)))
+    (is (= {:a 1}
+           (y/merge-maps nil {:a 1})))
+    (is (= {:a 3 :b 2}
+           (y/merge-maps {:a 1 :b 2} nil {:a 3})))))


### PR DESCRIPTION

## Summary

Updated `merge-maps` to safely ignore top-level `nil` map arguments before passing the remaining maps to `deep-merge-with`.

## Problem

Previously, passing `nil` as one of the map arguments could return unexpected nil or an `ArityException`.

For example:

```clojure
(merge-maps {:a 1} nil)
```

or:

```clojure
(merge-maps {:a 1 :b 2} nil {:a 3})
```

## Changes

- Added a private `remove-nil-maps` helper.
- Updated `merge-maps` to remove top-level `nil` arguments.
- Preserved the existing behavior where `nil` values inside maps remain valid override values.
- Added regression tests for `merge-maps` with `nil` map arguments.

## New Behavior

Top-level `nil` map arguments are ignored:

```clojure
(merge-maps nil {:a 1})
;; => {:a 1}
```

```clojure
(merge-maps {:a 1} nil)
;; => {:a 1}
```

```clojure
(merge-maps
 {:a 1 :b 2}
 nil
 {:a 3})
;; => {:a 3 :b 2}
```

A `nil` value inside a map remains an explicit override:

```clojure
(merge-maps
 {:a 1}
 {:a nil})
;; => {:a nil}
```
```clojure
(merge-maps
 {:a 1}
 {:a nil})
 {:a 12}
;; => {:a 12}
```

## Validation

The test suite passes successfully:

```text
Ran 4 tests containing 87 assertions.
0 failures, 0 errors.
```